### PR TITLE
feat: let `package create <subcommand> -h` display help text

### DIFF
--- a/news/subcommand-help.rst
+++ b/news/subcommand-help.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Let ``package create <subcommand> -h`` display help text.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/scikit_package/scikit_package_app.py
+++ b/src/scikit_package/scikit_package_app.py
@@ -12,7 +12,9 @@ SKPKG_GITHUB_URL = "https://github.com/scikit-package/scikit-package"
 def _add_subcommands(subparsers, commands, func, special_args={}):
     """Helper function to add subcommands to a parser."""
     for command, help_text in commands:
-        parser_sub = subparsers.add_parser(command, help=help_text)
+        parser_sub = subparsers.add_parser(
+            command, help=help_text, epilog=help_text
+        )
         if command in special_args:
             special_args[command](parser_sub)
         parser_sub.set_defaults(func=func, subcommand=command)


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

Closes #589. Display help message for `package create <subcommand> -h`.

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
Please see the inputs/outputs.
```
❯ package create manuscript -h                                                   
usage: package create manuscript [-h]

options:
  -h, --help  show this help message and exit

Create Overleaf LaTeX template of Billinge group.
```

Other `package create <subcommand> -h` is also enabled, e.g.
```
❯ package create public -h    
usage: package create public [-h]

options:
  -h, --help  show this help message and exit

Create a public package
```

Also, do we want to change the current help message for `package create manuscript -h`? Like "Create a LaTeX manuscript project", since now we want to recommend it to users outside the Billing group, and it is now less related to Overleaf.
